### PR TITLE
🚑Fix ability to have SSL certs in folders

### DIFF
--- a/traccar/rootfs/etc/cont-init.d/nginx.sh
+++ b/traccar/rootfs/etc/cont-init.d/nginx.sh
@@ -18,8 +18,8 @@ if bashio::var.has_value "${port}"; then
         keyfile=$(bashio::config 'keyfile')
 
         mv /etc/nginx/servers/direct-ssl.disabled /etc/nginx/servers/direct.conf
-        sed -i "s~%%certfile%%~${certfile}~g" /etc/nginx/servers/direct.conf
-        sed -i "s~%%keyfile%%~${keyfile}~g" /etc/nginx/servers/direct.conf
+        sed -i "s#%%certfile%%#${certfile}#g" /etc/nginx/servers/direct.conf
+        sed -i "s#%%keyfile%%#${keyfile}#g" /etc/nginx/servers/direct.conf
 
     else
         mv /etc/nginx/servers/direct.disabled /etc/nginx/servers/direct.conf

--- a/traccar/rootfs/etc/cont-init.d/nginx.sh
+++ b/traccar/rootfs/etc/cont-init.d/nginx.sh
@@ -18,8 +18,8 @@ if bashio::var.has_value "${port}"; then
         keyfile=$(bashio::config 'keyfile')
 
         mv /etc/nginx/servers/direct-ssl.disabled /etc/nginx/servers/direct.conf
-        sed -i "s/%%certfile%%/${certfile}/g" /etc/nginx/servers/direct.conf
-        sed -i "s/%%keyfile%%/${keyfile}/g" /etc/nginx/servers/direct.conf
+        sed -i "s~%%certfile%%~${certfile}~g" /etc/nginx/servers/direct.conf
+        sed -i "s~%%keyfile%%~${keyfile}~g" /etc/nginx/servers/direct.conf
 
     else
         mv /etc/nginx/servers/direct.disabled /etc/nginx/servers/direct.conf


### PR DESCRIPTION
# Proposed Changes

Change sed command to use `~` instead of `/` for SSL files so folders can be entered in the config

## Related Issues

Fixed #23 