### PR TITLE
Remove obsolete webui from configuration

### DIFF
--- a/traccar/config.json
+++ b/traccar/config.json
@@ -4,7 +4,6 @@
   "slug": "traccar",
   "description": "Modern GPS Tracking Platform",
   "url": "https://github.com/hassio-addons/addon-traccar",
-  "webui": "[PROTO:ssl]://[HOST]:[PORT:80]",
   "ingress": true,
   "ingress_port": 0,
   "panel_icon": "mdi:car-connected",


### PR DESCRIPTION
# Proposed Changes

No longer needed, as this add-on uses Ingress.
