### PR TITLE
Fix typo in Ingress NGINX template

### DIFF
--- a/traccar/rootfs/etc/nginx/templates/ingress.gtpl
+++ b/traccar/rootfs/etc/nginx/templates/ingress.gtpl
@@ -1,5 +1,5 @@
 server {
-    listen {{ .interface }}:{{ . port }} default_server;
+    listen {{ .interface }}:{{ .port }} default_server;
 
     include /etc/nginx/includes/server_params.conf;
     include /etc/nginx/includes/proxy_params.conf;


### PR DESCRIPTION
# Proposed Changes

Fixes a typo in the NGINX template for the Ingress host:

```
[cont-init.d] nginx.sh: executing... 
panic: template: tempIO:2: function "port" not defined

goroutine 1 [running]:
text/template.Must(...)
	/opt/hostedtoolcache/go/1.15.6/x64/src/text/template/helper.go:23
main.renderTemplateBuffer(0xc00000e058, 0xc000172000, 0x145, 0x345, 0x345, 0x0, 0x0)
	/home/runner/work/tempio/tempio/template.go:27 +0x2a9
main.renderTemplateFile(0xc00000e058, 0x7ffcccf4bd4a, 0x21, 0x4, 0x0, 0x0)
	/home/runner/work/tempio/tempio/template.go:19 +0x8b
main.main()
	/home/runner/work/tempio/tempio/main.go:28 +0x1c9
```
