### PR TITLE
:arrow_up: Upgrades Traccar to v4.12

### DIFF
--- a/traccar/Dockerfile
+++ b/traccar/Dockerfile
@@ -21,7 +21,7 @@ RUN \
         xmlstarlet=1.6.1-r0 \
     \
     && curl -J -L -o /tmp/traccar.zip \
-      "https://github.com/traccar/traccar/releases/download/v4.11/traccar-other-4.11.zip" \
+      "https://github.com/traccar/traccar/releases/download/v4.12/traccar-other-4.12.zip" \
     \
     && mkdir -p /opt/traccar \
     && unzip -d /opt/traccar /tmp/traccar.zip \


### PR DESCRIPTION
# Proposed Changes

Upgrades Traccar to v4.12:

https://github.com/traccar/traccar/releases/tag/v4.12
