### PR TITLE
Drop support for 32-bits systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,8 +108,8 @@ SOFTWARE.
 
 [aarch64-shield]: https://img.shields.io/badge/aarch64-yes-green.svg
 [amd64-shield]: https://img.shields.io/badge/amd64-yes-green.svg
-[armhf-shield]: https://img.shields.io/badge/armhf-yes-green.svg
-[armv7-shield]: https://img.shields.io/badge/armv7-yes-green.svg
+[armhf-shield]: https://img.shields.io/badge/armhf-no-red.svg
+[armv7-shield]: https://img.shields.io/badge/armv7-no-red.svg
 [commits-shield]: https://img.shields.io/github/commit-activity/y/hassio-addons/addon-traccar.svg
 [commits]: https://github.com/hassio-addons/addon-traccar/commits/main
 [contributors]: https://github.com/hassio-addons/addon-traccar/graphs/contributors
@@ -124,7 +124,7 @@ SOFTWARE.
 [github-actions]: https://github.com/hassio-addons/addon-traccar/actions
 [github-sponsors-shield]: https://frenck.dev/wp-content/uploads/2019/12/github_sponsor.png
 [github-sponsors]: https://github.com/sponsors/frenck
-[i386-shield]: https://img.shields.io/badge/i386-yes-green.svg
+[i386-shield]: https://img.shields.io/badge/i386-no-red.svg
 [issue]: https://github.com/hassio-addons/addon-traccar/issues
 [license-shield]: https://img.shields.io/github/license/hassio-addons/addon-traccar.svg
 [maintenance-shield]: https://img.shields.io/maintenance/yes/2021.svg

--- a/traccar/build.json
+++ b/traccar/build.json
@@ -1,9 +1,6 @@
 {
   "build_from": {
     "aarch64": "ghcr.io/hassio-addons/base/aarch64:10.0.0",
-    "amd64": "ghcr.io/hassio-addons/base/amd64:10.0.0",
-    "armhf": "ghcr.io/hassio-addons/base/armhf:10.0.0",
-    "armv7": "ghcr.io/hassio-addons/base/armv7:10.0.0",
-    "i386": "ghcr.io/hassio-addons/base/i386:10.0.0"
+    "amd64": "ghcr.io/hassio-addons/base/amd64:10.0.0"
   }
 }

--- a/traccar/config.json
+++ b/traccar/config.json
@@ -8,7 +8,7 @@
   "ingress_port": 0,
   "panel_icon": "mdi:car-connected",
   "startup": "services",
-  "arch": ["aarch64", "amd64", "armhf", "armv7", "i386"],
+  "arch": ["aarch64", "amd64"],
   "init": false,
   "host_network": true,
   "ports": {


### PR DESCRIPTION
# Proposed Changes

For upcoming upgrades of Traccar and its requirements, it is no longer possible to maintain a working add-on for 32-bits systems.

This PR removes support for`i386`, `armhf` and `armv7` systems.

It also prevents existing users to upgrade to a broken add-on. They can keep running their existing version, but won't be able to upgrade.
