### PR TITLE
🔥 Less logging by removing access log from log ouput

### DIFF
--- a/traccar/rootfs/etc/nginx/nginx.conf
+++ b/traccar/rootfs/etc/nginx/nginx.conf
@@ -24,11 +24,7 @@ events {
 http {
     include /etc/nginx/includes/mime.types;
 
-    log_format homeassistant '[$time_local] $status '
-                             '$http_x_forwarded_for($remote_addr) '
-                             '$request ($http_user_agent)';
-
-    access_log              /proc/1/fd/1 homeassistant;
+    access_log              off;
     client_max_body_size    4G;
     default_type            application/octet-stream;
     gzip                    on;


### PR DESCRIPTION
# Proposed Changes

Reduce add-on log ouput by removing access logging from NGINX