### PR TITLE
Update mysql.sh

### DIFF
--- a/traccar/rootfs/etc/cont-init.d/mysql.sh
+++ b/traccar/rootfs/etc/cont-init.d/mysql.sh
@@ -30,7 +30,7 @@ if bashio::services.available "mysql"; then
 
   # Update Traccar XML configuration for database
   xmlstarlet ed -L -s /properties \
-    -t elem -n entry_placeholder -v "com.mysql.jdbc.Driver" \
+    -t elem -n entry_placeholder -v "com.mysql.cj.jdbc.Driver" \
       -i //entry_placeholder -t attr -n "key" -v "database.driver" \
     -r //entry_placeholder -v entry \
     "${CONFIG}"


### PR DESCRIPTION
Loading class `com.mysql.jdbc.Driver'. This is deprecated. The new driver class is `com.mysql.cj.jdbc.Driver'. The driver is automatically registered via the SPI and manual loading of the driver class is generally unnecessary.

# Proposed Changes

> (Describe the changes and rationale behind them)

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
