### PR TITLE
Fix HTTP 415 unsupported media bug

### DIFF
--- a/traccar/config.yaml
+++ b/traccar/config.yaml
@@ -6,7 +6,6 @@ description: Modern GPS Tracking Platform
 url: https://github.com/hassio-addons/addon-traccar
 ingress: true
 ingress_port: 0
-ingress_stream: true
 panel_icon: mdi:car-connected
 startup: services
 arch:

--- a/traccar/rootfs/etc/nginx/templates/ingress.gtpl
+++ b/traccar/rootfs/etc/nginx/templates/ingress.gtpl
@@ -7,10 +7,13 @@ server {
     allow   172.30.32.2;
     deny    all;
 
-    location / {
-        allow   172.30.32.2;
-        deny    all;
+    location ~* /session$ {
+        proxy_set_header Content-Type application/x-www-form-urlencoded;
+        proxy_pass http://backend;
+    }
 
+    location / {
+        proxy_set_header Content-Type application/json;
         proxy_pass http://backend;
     }
 }


### PR DESCRIPTION
# Proposed Changes

Fixes: `Error: HTTP 415 Unsupported Media Type - NotSupportedException (...)`

Which occurs during ingress, it seems like some header got lost. Set the JSON header by default (other parts don't care) and make sure the session uses a form-data content type.

For now, I've disabled the Ingress streaming feature.

## Related Issues

fixes #119
