### PR TITLE
⬆️ Upgrades openjdk11-jre-headless to 11.0.14_p9-r0

### DIFF
--- a/traccar/Dockerfile
+++ b/traccar/Dockerfile
@@ -17,7 +17,7 @@ RUN \
         mariadb-client=10.6.7-r0 \
         nginx=1.20.2-r0 \
         nss=3.72.1-r0 \
-        openjdk11-jre-headless=11.0.13_p8-r0 \
+        openjdk11-jre-headless=11.0.14_p9-r0 \
         xmlstarlet=1.6.1-r0 \
     \
     && curl -J -L -o /tmp/traccar.zip \


### PR DESCRIPTION
# Proposed Changes

Upgrades openjdk11-jre-headless to 11.0.14_p9-r0
