### PR TITLE
Upgrade Traccar to v5.5

### DIFF
--- a/traccar/Dockerfile
+++ b/traccar/Dockerfile
@@ -15,7 +15,7 @@ WORKDIR /opt/traccar
 RUN \
     apk add --no-cache \
         mariadb-client=10.6.9-r0 \
-        nginx=1.22.0-r1 \
+        nginx=1.22.1-r0 \
         nss=3.78.1-r0 \
         openjdk11-jre-headless=11.0.17_p8-r1 \
         xmlstarlet=1.6.1-r0 \

--- a/traccar/Dockerfile
+++ b/traccar/Dockerfile
@@ -17,7 +17,7 @@ RUN \
         mariadb-client=10.6.9-r0 \
         nginx=1.22.0-r1 \
         nss=3.78.1-r0 \
-        openjdk11-jre-headless=11.0.16.1_p1-r0 \
+        openjdk11-jre-headless=11.0.17_p8-r1 \
         xmlstarlet=1.6.1-r0 \
     \
     && curl -J -L -o /tmp/traccar.zip \

--- a/traccar/Dockerfile
+++ b/traccar/Dockerfile
@@ -14,7 +14,7 @@ WORKDIR /opt/traccar
 # Setup base
 RUN \
     apk add --no-cache \
-        mariadb-client=10.6.9-r0 \
+        mariadb-client=10.6.10-r0 \
         nginx=1.22.1-r0 \
         nss=3.78.1-r0 \
         openjdk11-jre-headless=11.0.17_p8-r1 \

--- a/traccar/Dockerfile
+++ b/traccar/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM=ghcr.io/hassio-addons/base:12.2.4
+ARG BUILD_FROM=ghcr.io/hassio-addons/base:12.2.7
 # hadolint ignore=DL3006
 FROM ${BUILD_FROM}
 

--- a/traccar/Dockerfile
+++ b/traccar/Dockerfile
@@ -21,7 +21,7 @@ RUN \
         xmlstarlet=1.6.1-r0 \
     \
     && curl -J -L -o /tmp/traccar.zip \
-      "https://github.com/traccar/traccar/releases/download/v5.0/traccar-other-5.0.zip" \
+      "https://github.com/traccar/traccar/releases/download/v5.5/traccar-other-5.5.zip" \
     \
     && mkdir -p /opt/traccar \
     && unzip -d /opt/traccar /tmp/traccar.zip \


### PR DESCRIPTION
# Proposed Changes

This PR bumps the base image to 12.2.7, bumps all the dependencies to the latest version available on 12.2.7 base image, and upgrades Traccar to v5.5. this upgrade is critical since v5.0 of traccar misses manny substantial features in the modern UI.
this patch was tested locally and is fully compatible upgrading from traccar 5.0 / addon  v0.17.0.

## Related Issues
Solves #192 

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
