### PR TITLE
Migrate Traccar config out of Home Assistant config folder

### DIFF
--- a/traccar/DOCS.md
+++ b/traccar/DOCS.md
@@ -106,7 +106,7 @@ been done to reduce the number of open ports the add-on would create.
 
 By default, only the OsmAnd protocol (used by the Traccar Apps) and the API
 are enabled. If you want more protocols, you can do so, by adding entries
-to your `/config/traccar.xml` file.
+to your `traccar.xml` file in the add-on configuration folder.
 
 A list if all entries can be found here:
 

--- a/traccar/config.yaml
+++ b/traccar/config.yaml
@@ -18,7 +18,8 @@ ports:
 ports_description:
   80/tcp: Web interface
 map:
-  - config:rw
+  - addon_config:rw
+  - homeassistant_config:rw
   - ssl
 services:
   - mysql:want

--- a/traccar/rootfs/etc/cont-init.d/traccar.sh
+++ b/traccar/rootfs/etc/cont-init.d/traccar.sh
@@ -8,6 +8,14 @@ declare password
 declare port
 declare username
 
+# Migrate add-on data from the Home Assistant config folder,
+# to the add-on configuration folder.
+if ! bashio::fs.directory_exists '/config/traccar.xml' \
+    && bashio::fs.file_exists '/homeassistant/traccar.xml'; then
+    mv /homeassistant/traccar.xml /config/traccar.xml \
+        || bashio::exit.nok "Failed to migrate Traccar configuration"
+fi
+
 if ! bashio::fs.file_exists "/config/traccar.xml"; then
     cp /etc/traccar/traccar.xml /config/traccar.xml
 else


### PR DESCRIPTION
# Proposed Changes

This moves the Aircast configuration out of the Home Assistant configuration folder into its own add-on configuration folder. This ensures the configuration is included in the add-on backups as well.

The database, of course, is still stored and back upped by the MariaDB add-on.
