### PR TITLE
Bring back support for Raspberry PI systems (armv7)

### DIFF
--- a/traccar/Dockerfile
+++ b/traccar/Dockerfile
@@ -1,33 +1,98 @@
-ARG BUILD_FROM=ghcr.io/hassio-addons/base:15.0.7
+ARG BUILD_FROM=ghcr.io/hassio-addons/debian-base/amd64:7.3.3
 # hadolint ignore=DL3006
 FROM ${BUILD_FROM}
+
+# Configure locale
+ENV \
+    LANG=en_US.UTF-8 \
+    LANGUAGE=en_US:en \
+    LC_ALL=en_US.UTF-8
 
 # Set shell
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-# Copy root filesystem
-COPY rootfs /
+# Setup base
+ARG BUILD_ARCH="amd64"
+ARG TRACCAR_VERSION="v5.12"
 
 # Set working dir
 WORKDIR /opt/traccar
 
-# Setup base
-ARG TRACCAR_VERSION="v5.12"
-RUN \
-    apk add --no-cache \
-        mariadb-client=10.11.6-r0 \
-        nginx=1.24.0-r15 \
-        nss=3.97-r0 \
-        openjdk11-jre-headless=11.0.22_p7-r0 \
-        xmlstarlet=1.6.1-r2 \
+ENV JAVA_HOME /opt/java/openjdk
+ENV PATH $JAVA_HOME/bin:$PATH
+
+RUN set -ex \
     \
-    && curl -J -L -o /tmp/traccar.zip \
-      "https://github.com/traccar/traccar/releases/download/${TRACCAR_VERSION}/traccar-other-${TRACCAR_VERSION#v}.zip" \
+    && apt-get update \
     \
-    && mkdir -p /opt/traccar \
-    && unzip -d /opt/traccar /tmp/traccar.zip \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        wget \
+        nginx=1.22.1-9 \
+        mariadb-client=1:10.11.6-0+deb12u1 \
+        xmlstarlet=1.6.1-3 \
+        unzip=6.0-28 \
+        # java.lang.UnsatisfiedLinkError: libfontmanager.so: libfreetype.so.6: cannot open shared object file: No such file or directory
+        # java.lang.NoClassDefFoundError: Could not initialize class sun.awt.X11FontManager
+        # https://github.com/docker-library/openjdk/pull/235#issuecomment-424466077
+        fontconfig=2.14.1-4 \
+        # utilities for keeping Ubuntu and OpenJDK CA certificates in sync
+        # https://github.com/adoptium/containers/issues/293
+        ca-certificates \
+        p11-kit=0.24.1-2 \
+        # locales ensures proper character encoding and locale-specific behaviors using en_US.UTF-8
+        locales=2.36-9+deb12u4 \
     \
-    && rm -fr /tmp/*
+    && sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen \
+    && locale-gen \
+    \
+    # Install OpenJDK 11 JRE from Adoptium
+    && \
+    case "${BUILD_ARCH}" in \
+    aarch64) \
+        ESUM='46e2bff7d5f419ac7c2fad29e78bfacf49ead4a2de1aba73b6329128f6d1f707'; \
+        BINARY_URL='https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.22%2B7/OpenJDK11U-jre_aarch64_linux_hotspot_11.0.22_7.tar.gz'; \
+        ;; \
+    amd64|i386) \
+        ESUM='3a0fec1b9ef38d6abd86cf11f6001772b086096b6ec2588d2a02f1fa86b2b1de'; \
+        BINARY_URL='https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.22%2B7/OpenJDK11U-jre_x64_linux_hotspot_11.0.22_7.tar.gz'; \
+        ;; \
+    armhf|armv7) \
+        ESUM='a5ab40aa53ecd413a8af738e66855d423e64b5389f876a4825e2cbdb45e9cfb3'; \
+        BINARY_URL='https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.22%2B7/OpenJDK11U-jre_arm_linux_hotspot_11.0.22_7.tar.gz'; \
+        ;; \
+    *) \
+        echo "Unsupported arch: ${BUILD_ARCH}"; \
+        exit 1; \
+        ;; \
+    esac \
+    && wget --progress=dot:giga -O /tmp/openjdk.tar.gz ${BINARY_URL} \
+    && echo "${ESUM} */tmp/openjdk.tar.gz" | sha256sum -c - \
+    && mkdir -p "$JAVA_HOME" \
+    && tar --extract \
+    --file /tmp/openjdk.tar.gz \
+    --directory "$JAVA_HOME" \
+    --strip-components 1 \
+    --no-same-owner \
+    \
+    # https://github.com/docker-library/openjdk/issues/331#issuecomment-498834472
+    && find "$JAVA_HOME/lib" -name '*.so' -exec dirname '{}' ';' | sort -u > /etc/ld.so.conf.d/docker-openjdk.conf \
+    && ldconfig \
+    # https://github.com/docker-library/openjdk/issues/212#issuecomment-420979840
+    # https://openjdk.java.net/jeps/341
+    && java -Xshare:dump \
+    \
+    # Install Traccar
+    && wget -qO /tmp/traccar.zip "https://github.com/traccar/traccar/releases/download/${TRACCAR_VERSION}/traccar-other-${TRACCAR_VERSION#v}.zip" \
+    && unzip -qo /tmp/traccar.zip -d /opt/traccar \
+    \
+    # Cleanup
+    && rm -f ${JAVA_HOME}/lib/src.zip \
+    && apt-get autoremove --yes unzip wget \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* /tmp/*
+
+# Copy root filesystem
+COPY rootfs /
 
 # Build arguments
 ARG BUILD_ARCH

--- a/traccar/build.yaml
+++ b/traccar/build.yaml
@@ -1,7 +1,8 @@
 ---
 build_from:
-  aarch64: ghcr.io/hassio-addons/base:15.0.7
-  amd64: ghcr.io/hassio-addons/base:15.0.7
+  aarch64: ghcr.io/hassio-addons/debian-base/aarch64:7.3.3
+  amd64: ghcr.io/hassio-addons/debian-base/amd64:7.3.3
+  armv7: ghcr.io/hassio-addons/debian-base/armv7:7.3.3
 codenotary:
   base_image: codenotary@frenck.dev
   signer: codenotary@frenck.dev

--- a/traccar/config.yaml
+++ b/traccar/config.yaml
@@ -11,6 +11,7 @@ startup: services
 arch:
   - aarch64
   - amd64
+  - armv7
 init: false
 host_network: true
 ports:


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

First off, @frenck thanks for the awesome job you did with this addon and many other pieces of Home Assistant!

Here's a summary of the reason for this PR:

PR #116 removed support for `i386`, `armhf` and `armv7` systems, leaving Raspberry PI users (among other hardware using the unsupported systems) without the possibility of upgrading the addon any longer.

After digging a bit about the reason that originated the PR, I found out that Traccar moved from Java 8 to Java 11 [[1]](https://github.com/traccar/traccar/commit/f24d4a256a8fc8e045f14ae9447f80ef9b8b28fd) in v4.13 [[2]](https://github.com/traccar/traccar/tree/v4.13). Presumably, that change caused that the addon container image failed to build, because the addon was using a base image based on Alpine, and Alpine's repos don't provide a package for OpenJDK 11 for ARM systems [[3]](https://dl-cdn.alpinelinux.org/alpine/v3.19/community/armv7/).

To overcome that limitation, I changed the base image from Alpine to Debian and used the prebuilt OpenJDK packages provided by Adoptium [[4]](https://adoptium.net/temurin/releases/?os=linux&arch=any) to install Java 11 in all supported systems. The downside is that the Dockerfile is a bit longer, but IMO the benefits justify it. 

I have tested this in my own HA deployment on a RPI 4 and works perfectly well.  I'm now able to use the latest Traccar with my tracking devices.

Please let me know what you think and if any of my assumption are not correct. I'm happy to make any changes requested by the maintainers.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/

- #116 
- [1] https://github.com/traccar/traccar/commit/f24d4a256a8fc8e045f14ae9447f80ef9b8b28fd
- [2] https://github.com/traccar/traccar/tree/v4.13
- [3] https://dl-cdn.alpinelinux.org/alpine/v3.19/community/armv7/
- [4] https://adoptium.net/temurin/releases/?os=linux&arch=any
- [Traccar forum: Running 4.15 on raspberry pi within docker container](https://www.traccar.org/forums/topic/running-415-on-raspberry-pi-within-docker-container/)
