### PR TITLE
Add --skip-ssl option to MySQL commands

### DIFF
--- a/traccar/rootfs/etc/cont-init.d/mysql.sh
+++ b/traccar/rootfs/etc/cont-init.d/mysql.sh
@@ -26,7 +26,7 @@ if bashio::services.available "mysql"; then
 
   # Create database if not exists
   echo "CREATE DATABASE IF NOT EXISTS traccar;" \
-    | mysql -h "${host}" -P "${port}" -u "${username}" -p"${password}"
+    | mysql --skip-ssl -h "${host}" -P "${port}" -u "${username}" -p"${password}"
 
   # Update Traccar XML configuration for database
   xmlstarlet ed -L -s /properties \

--- a/traccar/rootfs/etc/cont-init.d/traccar.sh
+++ b/traccar/rootfs/etc/cont-init.d/traccar.sh
@@ -28,7 +28,7 @@ else
         username=$(bashio::services "mysql" "username")
 
         echo "UPDATE DATABASECHANGELOGLOCK SET locked=0;" \
-            | mysql -h "${host}" -P "${port}" -u "${username}" -p"${password}" \
+            | mysql --skip-ssl -h "${host}" -P "${port}" -u "${username}" -p"${password}" \
                 traccar || true
     fi
 fi


### PR DESCRIPTION
# Proposed Changes

fixes cont-init: info: running /etc/cont-init.d/mysql.sh
mysql: Deprecated program name. It will be removed in a future release, use '/usr/bin/mariadb' instead
ERROR 2026 (HY000): TLS/SSL error: SSL is required, but the server does not support it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modified database initialization commands to adjust SSL connection settings for MySQL operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->